### PR TITLE
Make PixelFormat repr(transparent)

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -807,7 +807,7 @@ pub const PT_LabV2: PixelType = PixelType(30);
 ///            C: Channels (Samples per pixel)
 ///            B: bytes per sample
 ///            Y: Swap first - changes ABGR to BGRA and KCMY to CMYK
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct PixelFormat(pub u32);
 


### PR DESCRIPTION
This ensures that it represented as an actual u32 as in the C ABI. Fixes segfaults when returning this type on i386 systems.

Fixes kornelski/rust-lcms2#17