### PR TITLE
Update vendored lcms2 to 2.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lcms2-sys"
-version = "4.0.6"
+version = "4.0.7"
 authors = ["Kornel Lesiński <kornel@geekhood.net>"]
 build = "src/build.rs"
 categories = ["multimedia::images", "external-ffi-bindings" ]


### PR DESCRIPTION
## Summary
- Update vendored Little CMS submodule from 2.17 to 2.18
- Bump crate version to 4.0.7
- Includes signed integer overflow fixes, out-of-bounds read fixes, and Microsoft MHC2 private tag fixes

No build.rs changes needed — no new source files were added between 2.17 and 2.18.